### PR TITLE
Delete the `LandMine` class

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -333,8 +333,7 @@ class ClinicWholeFileTest(_ParserBase):
             [clinic start generated code]*/
         """)
         msg = (
-            "Stepped on a land mine, trying to access attribute 'noaccess':\n"
-            "Don't access members of self.function inside converter_init!"
+            "accessing self.function inside converter_init is disallowed!"
         )
         self.assertIn(msg, out)
 

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2845,10 +2845,10 @@ class CConverter(metaclass=CConverterAutoRegister):
     if not TYPE_CHECKING:
         def __getattr__(self, attr):
             if attr == "function":
-                raise AttributeError(
+                fail(
                     f"{self.__class__.__name__!r} object has no attribute 'function'.\n"
                     f"Note: accessing self.function inside converter_init is disallowed!"
-                ) from None
+                )
             return super().__getattr__(attr)
 
     def converter_init(self) -> None:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2844,15 +2844,12 @@ class CConverter(metaclass=CConverterAutoRegister):
     # so put it inside an `if not TYPE_CHECKING` block
     if not TYPE_CHECKING:
         def __getattr__(self, attr):
-            try:
-                return super().__getattr__(attr)
-            except AttributeError as e:
-                if attr == "function":
-                    e.add_note(
-                        "Note: accessing self.function "
-                        "inside converter_init is disallowed!"
-                    )
-                raise
+            if attr == "function":
+                raise AttributeError(
+                    f"{self.__class__.__name__!r} object has no attribute 'function'.\n"
+                    f"Note: accessing self.function inside converter_init is disallowed!"
+                ) from None
+            return super().__getattr__(attr)
 
     def converter_init(self) -> None:
         pass

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2831,6 +2831,10 @@ class CConverter(metaclass=CConverterAutoRegister):
         if annotation is not unspecified:
             fail("The 'annotation' parameter is not currently permitted.")
 
+        # Make sure not to set self.function until after converter_init() has been called.
+        # This prevents you from caching information
+        # about the function in converter_init().
+        # (That breaks if we get cloned.)
         self.converter_init(**kwargs)
         self.function = function
 


### PR DESCRIPTION
@erlend-aasland, what do you think about this? It simplifies some of the typing, since now `CConverter.function` is always an instance of Function, instead of sometimes being an instance of `LandMine`. I'm not sure why we need to temporarily set `self.function` to be an instance of `LandMine` -- I feel like we can get the same effect by just not setting `self.function` until after `converter_init()` has been called. But I'm a bit wary of Chesterton's Fence here -- I'm not sure I understand fully exactly which problem the `self.function = LandMine()` thing was originally supposed to solve.