### PR TITLE
PoC: Use logging for warnings

### DIFF
--- a/Tools/clinic/libclinic/__init__.py
+++ b/Tools/clinic/libclinic/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Final
 
 from .errors import (
@@ -17,6 +18,18 @@ from .formatting import (
 )
 
 
+def get_logger(level: int = logging.WARNING) -> logging.Logger:
+    fmt = logging.Formatter("%(levelname)s: %(message)s")
+
+    console = logging.StreamHandler()
+    console.setLevel(level)
+    console.setFormatter(fmt)
+
+    logger = logging.getLogger("clinic")
+    logger.addHandler(console)
+    return logger
+
+
 __all__ = [
     # Error handling
     "ClinicError",
@@ -32,6 +45,9 @@ __all__ = [
     "suffix_all_lines",
     "wrap_declarations",
     "wrapped_c_string_literal",
+
+    # Misc
+    "get_logger",
 ]
 
 

--- a/Tools/clinic/libclinic/errors.py
+++ b/Tools/clinic/libclinic/errors.py
@@ -11,12 +11,12 @@ class ClinicError(Exception):
     def __post_init__(self) -> None:
         super().__init__(self.message)
 
-    def report(self, *, warn_only: bool = False) -> str:
-        msg = "Warning" if warn_only else "Error"
+    def __str__(self) -> str:
+        msg = "Error "
         if self.filename is not None:
-            msg += f" in file {self.filename!r}"
+            msg += f"in file {self.filename!r}"
         if self.lineno is not None:
-            msg += f" on line {self.lineno}"
+            msg += f"on line {self.lineno}"
         msg += ":\n"
         msg += f"{self.message}\n"
         return msg


### PR DESCRIPTION
Another experiment: tear out the custom warning functionality, and instead use `logging.warning`.

Pro: simplified error handling code
Con: no line numbers for warnings[^1]

[^1]: well, there were never usable line numbers for warnings anyway