### PR TITLE
PoC: Use a lexer to more easily identify invalid syntax

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -600,7 +600,7 @@ class ClinicWholeFileTest(TestCase):
             foo as = foo2
             [clinic start generated code]*/
         """
-        err = "No C basename provided after 'as' keyword"
+        err = "No C basename provided for 'foo' after 'as' keyword"
         self.expect_failure(block, err, lineno=5)
 
     def test_cloned_with_custom_c_basename(self):
@@ -1528,7 +1528,7 @@ class ClinicParserTest(TestCase):
             foo.bar => int
                 /
         """
-        err = "Illegal function name: 'foo.bar => int'"
+        err = "Invalid syntax: 'foo.bar => int'"
         self.expect_failure(block, err)
 
     def test_illegal_c_basename(self):
@@ -1542,7 +1542,7 @@ class ClinicParserTest(TestCase):
 
     def test_no_c_basename(self):
         block = "foo as "
-        err = "No C basename provided after 'as' keyword"
+        err = "No C basename provided for 'foo' after 'as' keyword"
         self.expect_failure(block, err, strip=False)
 
     def test_single_star(self):

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -39,7 +39,6 @@ from typing import (
     Any,
     Final,
     Literal,
-    NamedTuple,
     NoReturn,
     Protocol,
     TypeVar,
@@ -4838,11 +4837,6 @@ class ParamState(enum.IntEnum):
     RIGHT_SQUARE_AFTER = 6
 
 
-class FunctionNames(NamedTuple):
-    full_name: str
-    c_basename: str
-
-
 class DSLParser:
     function: Function | None
     state: StateKeeper
@@ -5126,25 +5120,6 @@ class DSLParser:
 
         self.next(self.state_modulename_name, line)
 
-    def parse_function_names(self, line: str) -> FunctionNames:
-        left, as_, right = line.partition(' as ')
-        full_name = left.strip()
-        c_basename = right.strip()
-        if as_ and not c_basename:
-            fail("No C basename provided after 'as' keyword")
-        if not c_basename:
-            fields = full_name.split(".")
-            if fields[-1] == '__new__':
-                fields.pop()
-            c_basename = "_".join(fields)
-        if not is_legal_py_identifier(full_name):
-            fail(f"Illegal function name: {full_name!r}")
-        if not is_legal_c_identifier(c_basename):
-            fail(f"Illegal C basename: {c_basename!r}")
-        names = FunctionNames(full_name=full_name, c_basename=c_basename)
-        self.normalize_function_kind(names.full_name)
-        return names
-
     def normalize_function_kind(self, fullname: str) -> None:
         # Fetch the method name and possibly class.
         fields = fullname.split('.')
@@ -5168,7 +5143,7 @@ class DSLParser:
             self.kind = METHOD_INIT
 
     def resolve_return_converter(
-        self, full_name: str, forced_converter: str
+        self, full_name: str, forced_converter: str | None
     ) -> CReturnConverter:
         if forced_converter:
             if self.kind in {GETTER, SETTER}:
@@ -5194,8 +5169,19 @@ class DSLParser:
             return init_return_converter()
         return CReturnConverter()
 
-    def parse_cloned_function(self, names: FunctionNames, existing: str) -> None:
-        full_name, c_basename = names
+    @staticmethod
+    def generate_c_basename(full_name: str) -> str:
+        fields = full_name.split(".")
+        if fields[-1] == '__new__':
+            fields.pop()
+        return "_".join(fields)
+
+    def parse_cloned_function(
+        self,
+        full_name: str,
+        c_basename: str,
+        existing: str
+    ) -> None:
         fields = [x.strip() for x in existing.split('.')]
         function_name = fields.pop()
         module, cls = self.clinic._module_and_class(fields)
@@ -5237,6 +5223,51 @@ class DSLParser:
         (cls or module).functions.append(function)
         self.next(self.state_function_docstring)
 
+    def parse_modulename_name(
+        self,
+        line: str
+    ) -> tuple[str, str, str | None, str | None]:
+        full_name: str
+        c_basename: str = ""
+        cloned: str | None = None
+        returns: str | None = None
+
+        # Parse line.
+        tokens = libclinic.generate_tokens(line)
+        match [t.token for t in tokens]:
+            # Valid syntax:
+            case [full_name]: ...
+            case [full_name, "as", c_basename]: ...
+            case [full_name, "->", *_]:
+                pos = tokens[2].pos
+                returns = line[pos:].strip()
+            case [full_name, "=", cloned]: ...
+            case [full_name, "as", c_basename, "=", cloned]: ...
+            case [full_name, "as", c_basename, "->", returns]: ...
+
+            # Invalid syntax:
+            case [full_name, "as"] | [full_name, "as", "=", *_]:
+                fail(f"No C basename provided for {full_name!r} after 'as' keyword")
+            case [full_name, "as", _, "->"]:
+                fail(f"No return annotation provided for {full_name!r} after '->' keyword")
+            case [full_name, "as", _, "="]:
+                fail(f"No source function provided for {full_name!r} after '=' keyword")
+            case _:
+                fail(f"Invalid syntax: {line!r}\n\n"
+                     "Allowed syntax:\n"
+                     "[module.[submodule.]][class.]func [as c_name] [-> return_annotation]")
+
+        # Validate input.
+        if not c_basename:
+            c_basename = self.generate_c_basename(full_name)
+        if not is_legal_py_identifier(full_name):
+            fail(f"Illegal function name: {full_name!r}")
+        if not is_legal_c_identifier(c_basename):
+            fail(f"Illegal C basename: {c_basename!r}")
+        self.normalize_function_kind(full_name)
+
+        return full_name, c_basename, cloned, returns
+
     def state_modulename_name(self, line: str) -> None:
         # looking for declaration, which establishes the leftmost column
         # line should be
@@ -5257,20 +5288,15 @@ class DSLParser:
         assert self.valid_line(line)
         self.indent.infer(line)
 
-        # are we cloning?
-        before, equals, existing = line.rpartition('=')
-        if equals:
-            existing = existing.strip()
-            if is_legal_py_identifier(existing):
-                # we're cloning!
-                names = self.parse_function_names(before)
-                return self.parse_cloned_function(names, existing)
+        full_name, c_basename, cloned, returns = self.parse_modulename_name(line)
 
-        line, _, returns = line.partition('->')
-        returns = returns.strip()
-        full_name, c_basename = self.parse_function_names(line)
+        # Handle cloning.
+        if cloned and is_legal_py_identifier(cloned):
+            return self.parse_cloned_function(full_name, c_basename, cloned)
+
         return_converter = self.resolve_return_converter(full_name, returns)
 
+        # Split out function name, and determine module and class.
         fields = [x.strip() for x in full_name.split('.')]
         function_name = fields.pop()
         module, cls = self.clinic._module_and_class(fields)

--- a/Tools/clinic/libclinic/__init__.py
+++ b/Tools/clinic/libclinic/__init__.py
@@ -15,6 +15,7 @@ from .formatting import (
     wrap_declarations,
     wrapped_c_string_literal,
 )
+from .tokenizer import generate_tokens
 from .utils import (
     FormatCounterFormatter,
     compute_checksum,
@@ -38,6 +39,9 @@ __all__ = [
     "suffix_all_lines",
     "wrap_declarations",
     "wrapped_c_string_literal",
+
+    # Parsing helpers
+    "generate_tokens",
 
     # Utility functions
     "FormatCounterFormatter",

--- a/Tools/clinic/libclinic/tokenizer.py
+++ b/Tools/clinic/libclinic/tokenizer.py
@@ -1,0 +1,32 @@
+import io
+import shlex
+import dataclasses as dc
+from typing import Any
+
+
+@dc.dataclass
+class Token:
+    line: str
+    lineno: int
+    pos: int
+    token: str
+
+
+class Lexer(shlex.shlex):
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.wordchars += "."
+
+
+def generate_tokens(line: str, lineno: int = 0) -> list[Token]:
+    buf = io.StringIO(line)
+    lexer = Lexer(buf)
+    tokens: list[Token] = []
+    for idx, token in enumerate(lexer):
+        if idx and tokens[-1].token == "-" and token == ">":
+            tokens.pop()
+            token = "->"
+        pos = buf.tell() - len(token) - 1
+        tokens.append(Token(line, lineno, pos, token))
+    return tokens


### PR DESCRIPTION
Some parts of the parser state machine are a bit hairy; there is a lot of C&P snippets, and the places where we detect syntax error are scattered everywhere.

Here's an experiment:
- add a dead simple lexer based on shlex
- parse the input line to tokens and use pattern matching to separate valid and invalid syntax
- side effect: for errors, we'll now also get the position in the line (for better error messages)
- side effect: we can more easily detect invalid syntax